### PR TITLE
Vessel events layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalfishingwatch/layer-composer",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Tools to convert layer configuration to data structures needed in Mapbox GL GFW interactive maps ",
   "keywords": [
     "mapboxgl",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export {
   TYPES,
   HEATMAP_GEOM_TYPES,
   HEATMAP_COLOR_RAMPS,
-  dataTransforms,
+  getVesselEventsGeojson,
 } from './layer-composer/generators'
 
 export { default as sort, convertLegacyGroups } from './sort'

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   TYPES,
   HEATMAP_GEOM_TYPES,
   HEATMAP_COLOR_RAMPS,
+  dataTransforms,
 } from './layer-composer/generators'
 
 export { default as sort, convertLegacyGroups } from './sort'

--- a/src/layer-composer/generators/index.ts
+++ b/src/layer-composer/generators/index.ts
@@ -13,12 +13,18 @@ import HeatmapGenerator, {
 import TrackGenerator, { TRACK_TYPE as TRACK } from './track/track'
 import VesselEventsGenerator, {
   VESSEL_EVENTS_TYPE as VESSEL_EVENTS,
+  getVesselEventsGeojson,
 } from './vessel-events/vessel-events'
 
 const TYPES = { BASEMAP, CARTO_POLYGONS, BACKGROUND, GL, HEATMAP, TRACK, VESSEL_EVENTS }
 export { TYPES }
 
 export { HEATMAP_GEOM_TYPES, HEATMAP_COLOR_RAMPS }
+
+const dataTransforms = {
+  getVesselEventsGeojson,
+}
+export { dataTransforms }
 
 export default {
   [BACKGROUND]: new BackgroundGenerator(),

--- a/src/layer-composer/generators/index.ts
+++ b/src/layer-composer/generators/index.ts
@@ -21,10 +21,7 @@ export { TYPES }
 
 export { HEATMAP_GEOM_TYPES, HEATMAP_COLOR_RAMPS }
 
-const dataTransforms = {
-  getVesselEventsGeojson,
-}
-export { dataTransforms }
+export { getVesselEventsGeojson }
 
 export default {
   [BACKGROUND]: new BackgroundGenerator(),

--- a/src/layer-composer/generators/index.ts
+++ b/src/layer-composer/generators/index.ts
@@ -11,8 +11,11 @@ import HeatmapGenerator, {
   HEATMAP_COLOR_RAMPS,
 } from './heatmap/heatmap'
 import TrackGenerator, { TRACK_TYPE as TRACK } from './track/track'
+import VesselEventsGenerator, {
+  VESSEL_EVENTS_TYPE as VESSEL_EVENTS,
+} from './vessel-events/vessel-events'
 
-const TYPES = { BASEMAP, CARTO_POLYGONS, BACKGROUND, GL, HEATMAP, TRACK }
+const TYPES = { BASEMAP, CARTO_POLYGONS, BACKGROUND, GL, HEATMAP, TRACK, VESSEL_EVENTS }
 export { TYPES }
 
 export { HEATMAP_GEOM_TYPES, HEATMAP_COLOR_RAMPS }
@@ -24,4 +27,5 @@ export default {
   [CARTO_POLYGONS]: new CartoGenerator({ baseUrl: CARTO_FISHING_MAP_API }),
   [HEATMAP]: new HeatmapGenerator({}),
   [TRACK]: new TrackGenerator(),
+  [VESSEL_EVENTS]: new VesselEventsGenerator(),
 }

--- a/src/layer-composer/generators/vessel-events/vessel-events.ts
+++ b/src/layer-composer/generators/vessel-events/vessel-events.ts
@@ -1,0 +1,80 @@
+import { GeneratorConfig } from 'layer-composer/types'
+import { FeatureCollection } from 'geojson'
+import { GeoJSONSourceRaw } from 'mapbox-gl'
+
+export const VESSEL_EVENTS_TYPE = 'VESSEL_EVENTS'
+
+export interface VesselEventsGeneratorConfig extends GeneratorConfig {
+  data: FeatureCollection
+}
+
+const BASEMAP_COLOR = '#00265c'
+const EVENTS_COLORS = {
+  encounter: '#FAE9A0',
+  partially: '#F59E84',
+  unmatched: '#CE2C54',
+  loitering: '#cfa9f9',
+  port: '#99EEFF',
+}
+
+class VesselsEventsGenerator {
+  type = VESSEL_EVENTS_TYPE
+
+  _getStyleSources = (layer: VesselEventsGeneratorConfig) => {
+    const { id, data } = layer
+
+    if (!data) {
+      console.warn(`${VESSEL_EVENTS_TYPE} source generator needs geojson data`, layer)
+      return []
+    }
+
+    const source: GeoJSONSourceRaw = {
+      type: 'geojson',
+      data: data || null,
+    }
+    return [{ id, ...source }]
+  }
+
+  _getStyleLayers = (layer: VesselEventsGeneratorConfig) => {
+    if (!layer.data) {
+      console.warn(`${VESSEL_EVENTS_TYPE} source generator needs geojson data`, layer)
+      return []
+    }
+
+    const activeFilter = ['case', ['==', ['get', 'active'], true]]
+    const layers: any[] = [
+      {
+        id: 'vessel_events_bg',
+        type: 'circle',
+        source: layer.id,
+        paint: {
+          'circle-color': ['get', 'color'],
+          'circle-stroke-width': 2,
+          'circle-stroke-color': [...activeFilter, 'rgba(0, 193, 231, 1)', BASEMAP_COLOR],
+          'circle-radius': [...activeFilter, 12, 5],
+        },
+      },
+      {
+        id: 'vessel_events',
+        source: layer.id,
+        type: 'symbol',
+        layout: {
+          'icon-allow-overlap': true,
+          'icon-image': ['get', 'icon'],
+          'icon-size': [...activeFilter, 1, 0],
+        },
+      },
+    ]
+    return layers
+  }
+
+  getStyle = (layer: VesselEventsGeneratorConfig) => {
+    return {
+      id: layer.id,
+      sources: this._getStyleSources(layer),
+      layers: this._getStyleLayers(layer),
+    }
+  }
+}
+
+export default VesselsEventsGenerator

--- a/src/layer-composer/layer-composer.ts
+++ b/src/layer-composer/layer-composer.ts
@@ -78,7 +78,7 @@ class LayerComposer {
     globalConfig: GlobalGeneratorConfig
   ): GeneratorStyles => {
     if (!this.generators[config.type]) {
-      throw new Error(`There is no generator loaded for the config: ${config}}`)
+      throw new Error(`There is no generator loaded for the config: ${config.type}}`)
     }
     const finalConfig = {
       ...globalConfig,

--- a/src/layer-composer/types.ts
+++ b/src/layer-composer/types.ts
@@ -29,7 +29,15 @@ export interface Generator {
 
 export interface GeneratorConfig {
   id: string
-  type: 'BACKGROUND' | 'BASEMAP' | 'CARTO_POLYGONS' | 'GL_STYLES' | 'HEATMAP' | string
+  type:
+    | 'BACKGROUND'
+    | 'BASEMAP'
+    | 'CARTO_POLYGONS'
+    | 'GL_STYLES'
+    | 'HEATMAP'
+    | 'TRACK'
+    | 'VESSEL_EVENTS'
+    | string
   visible?: boolean
   opacity?: number
   start?: string


### PR DESCRIPTION
Moves CP vessel events layer to a generator here, plus data transformation logic.
Is there a reason why the API does not return a GeoJSON? We could avoid having most of this data transformation logic in the front end.