### PR TITLE
events highlight in track generator

### DIFF
--- a/src/layer-composer/generators/types.ts
+++ b/src/layer-composer/generators/types.ts
@@ -89,6 +89,15 @@ export interface TrackGeneratorConfig extends GeneratorConfig {
     start: string
     end: string
   }
+  /**
+   * Sets a portion of the track to highlight visually
+   */
+  highlightedEvent?: {
+    start: string
+    end: string
+    color?: string
+    width?: number
+  }
 }
 
 export interface VesselEventsGeneratorConfig extends GeneratorConfig {


### PR DESCRIPTION
Move missing generator config from carrier portal to unify track-inspector and carrier-portal track generator.