### PR TITLE
Carrier colors review

### DIFF
--- a/src/layer-composer/generators/background/background.ts
+++ b/src/layer-composer/generators/background/background.ts
@@ -2,7 +2,7 @@ import { Layer } from 'mapbox-gl'
 import { Group } from '../../types'
 import { Type, BackgroundGeneratorConfig } from '../types'
 
-export const DEFAULT_BASEMAP_COLOR = '#00265c'
+export const DEFAULT_BASEMAP_COLOR = '#002457'
 
 class BackgroundGenerator {
   type = Type.Background

--- a/src/layer-composer/generators/basemap/basemap-layers.ts
+++ b/src/layer-composer/generators/basemap/basemap-layers.ts
@@ -8,7 +8,7 @@ export const BASEMAPS = {
 }
 
 const BASEMAP_VECTOR_SOURCE = 'basemap_vector'
-export const DEFAULT_LANDMASS_COLOR = '#203560'
+export const DEFAULT_LANDMASS_COLOR = '#274777'
 
 export const layers: Dictionary<Layer> = {
   [BASEMAPS.Satellite]: {
@@ -42,14 +42,7 @@ export const layers: Dictionary<Layer> = {
     },
     paint: {
       'line-color': '#ffffff',
-      'line-opacity': {
-        base: 1,
-        stops: [
-          [0, 0.1],
-          [8, 0.2],
-          [9, 0.2],
-        ],
-      },
+      'line-opacity': 0.2,
       'line-width': 0.5,
     },
   },

--- a/src/layer-composer/generators/carto-polygons/carto-polygons-layers.ts
+++ b/src/layer-composer/generators/carto-polygons/carto-polygons-layers.ts
@@ -11,9 +11,13 @@ export default {
     layers: [
       {
         id: 'cp_rfmo',
-        type: 'fill',
+        type: 'line',
         source: 'cp_rfmo',
         'source-layer': 'cp_rfmo',
+        layout: {
+          'line-cap': 'round',
+          'line-join': 'round',
+        },
         metadata: {
           group: Group.OutlinePolygons,
         },
@@ -28,9 +32,13 @@ export default {
     layers: [
       {
         id: 'sprfmo',
-        type: 'fill',
+        type: 'line',
         source: 'sprfmo',
         'source-layer': 'sprfmo',
+        layout: {
+          'line-cap': 'round',
+          'line-join': 'round',
+        },
         metadata: {
           group: Group.OutlinePolygons,
         },
@@ -46,25 +54,15 @@ export default {
     layers: [
       {
         id: 'mpant',
-        type: 'fill',
-        source: 'mpant',
-        'source-layer': 'mpant',
-        metadata: {
-          group: Group.OutlinePolygons,
-        },
-      },
-      {
-        id: 'mpant-labels',
-        type: 'symbol',
+        type: 'line',
         source: 'mpant',
         'source-layer': 'mpant',
         layout: {
-          'text-field': '{name}',
-          'text-font': ['Roboto Mono Light'],
-          'text-size': 10,
+          'line-cap': 'round',
+          'line-join': 'round',
         },
         metadata: {
-          group: Group.Label,
+          group: Group.OutlinePolygons,
         },
       },
     ],
@@ -72,29 +70,19 @@ export default {
   eez: {
     source: {
       sql:
-        "SELECT cartodb_id, CAST (mrgid AS TEXT) as id, the_geom, the_geom_webmercator, geoname as name, 'eez:' || mrgid as region_id, geoname as reporting_name, 'eez:' || mrgid as reporting_id FROM eez",
+        'SELECT cartodb_id, CAST (mrgid AS TEXT) as id, the_geom, the_geom_webmercator FROM eez_land_v3_202030',
       type: 'vector',
       attribution: 'EEZs: marineregions.org',
     },
     layers: [
       {
         id: 'eez',
-        type: 'fill',
-        source: 'eez',
-        'source-layer': 'eez',
-        metadata: {
-          group: Group.OutlinePolygons,
-        },
-      },
-      {
-        id: 'eez-labels',
-        type: 'symbol',
+        type: 'line',
         source: 'eez',
         'source-layer': 'eez',
         layout: {
-          'text-field': '{name}',
-          'text-font': ['Roboto Mono Light'],
-          'text-size': 10,
+          'line-cap': 'round',
+          'line-join': 'round',
         },
         metadata: {
           group: Group.BasemapPolygons,
@@ -110,27 +98,16 @@ export default {
     layers: [
       {
         id: 'bluefin_rfmo',
-        type: 'fill',
+        type: 'line',
         source: 'bluefin_rfmo',
         'source-layer': 'bluefin_rfmo',
+        layout: {
+          'line-cap': 'round',
+          'line-join': 'round',
+        },
         metadata: {
           group: Group.OutlinePolygons,
         },
-      },
-    ],
-  },
-  // TODO Move to Basemap generator
-  landmass: {
-    source: {
-      sql: 'SELECT the_geom, the_geom_webmercator, cartodb_id FROM landmass',
-      type: 'vector',
-    },
-    layers: [
-      {
-        id: 'landmass',
-        type: 'fill',
-        source: 'landmass',
-        'source-layer': 'landmass',
       },
     ],
   },

--- a/src/layer-composer/generators/carto-polygons/carto-polygons-layers.ts
+++ b/src/layer-composer/generators/carto-polygons/carto-polygons-layers.ts
@@ -85,7 +85,7 @@ export default {
           'line-join': 'round',
         },
         metadata: {
-          group: Group.BasemapPolygons,
+          group: Group.OutlinePolygonsBackground,
         },
       },
     ],

--- a/src/layer-composer/generators/carto-polygons/carto-polygons-layers.ts
+++ b/src/layer-composer/generators/carto-polygons/carto-polygons-layers.ts
@@ -97,7 +97,7 @@ export default {
           'text-size': 10,
         },
         metadata: {
-          group: Group.Label,
+          group: Group.BasemapPolygons,
         },
       },
     ],

--- a/src/layer-composer/generators/carto-polygons/carto-polygons.ts
+++ b/src/layer-composer/generators/carto-polygons/carto-polygons.ts
@@ -4,6 +4,7 @@ import { GeneratorStyles } from 'layer-composer/types'
 import { Type, CartoPolygonsGeneratorConfig } from '../types'
 
 export const CARTO_FISHING_MAP_API = 'https://carto.globalfishingwatch.org/user/admin/api/v1/map'
+const DEFAULT_LINE_COLOR = 'white'
 
 interface CartoLayerOptions {
   id: string
@@ -74,49 +75,48 @@ class CartoPolygonsGenerator {
     }
   }
 
-  _getStyleLayers = (layer: CartoPolygonsGeneratorConfig) => {
-    const isSourceReady = this.tilesCacheByid[layer.id] !== undefined
+  _getStyleLayers = (config: CartoPolygonsGeneratorConfig) => {
+    const isSourceReady = this.tilesCacheByid[config.id] !== undefined
 
-    const layerData = (layersDirectory as any)[layer.id] || layer
-    return layerData.layers.map((glLayer: any) => {
+    const layerData = (layersDirectory as any)[config.id] || config
+    const layers: any = layerData.layers.map((glLayer: any) => {
       if (!isSourceReady) return glLayer
 
       const visibility =
-        layer.visible !== undefined ? (layer.visible ? 'visible' : 'none') : 'visible'
-      const layout = { visibility }
+        config.visible !== undefined ? (config.visible ? 'visible' : 'none') : 'visible'
+      const layout = glLayer.layout ? { ...glLayer.layout, visibility } : { visibility }
       const paint: any = {}
-      const hasSelectedFeatures =
-        layer.selectedFeatures !== undefined &&
-        layer.selectedFeatures.values &&
-        layer.selectedFeatures.values.length
+      const hasSelectedFeatures = config.selectedFeatures?.values?.length
       // TODO: make this dynamic
-      if (glLayer.type === 'fill') {
-        paint['fill-opacity'] = layer.opacity !== undefined ? layer.opacity : 1
-        const fillColor = layer.fillColor || 'rgba(0,0,0,0)'
+      if (glLayer.type === 'line') {
+        paint['line-opacity'] = config.opacity !== undefined ? config.opacity : 1
+        paint['line-color'] = config.color || DEFAULT_LINE_COLOR
+      } else if (glLayer.type === 'fill') {
+        paint['fill-opacity'] = config.opacity !== undefined ? config.opacity : 1
+        const fillColor = config.fillColor || DEFAULT_LINE_COLOR
 
         if (hasSelectedFeatures) {
-          const { field = 'id', values, fill = {} } = layer.selectedFeatures
-          const { color = fillColor, fillOutlineColor = layer.color } = fill
-
+          const { field = 'id', values, fill = {} } = config.selectedFeatures
+          const { color = fillColor, fillOutlineColor = config.color } = fill
           const matchFilter = ['match', ['get', field], values]
           paint[`fill-color`] = [...matchFilter, color, fillColor]
-          paint[`fill-outline-color`] = [...matchFilter, fillOutlineColor, layer.color]
+          paint[`fill-outline-color`] = [...matchFilter, fillOutlineColor, config.color]
         } else {
           paint[`fill-color`] = fillColor
-          paint[`fill-outline-color`] = layer.color
+          paint[`fill-outline-color`] = config.color || DEFAULT_LINE_COLOR
         }
       } else if (glLayer.type === 'circle') {
-        const circleColor = layer.color || '#99eeff'
-        const circleOpacity = layer.opacity || 1
-        const circleStrokeColor = layer.strokeColor || 'hsla(190, 100%, 45%, 0.5)'
-        const circleStrokeWidth = layer.strokeWidth || 2
-        const circleRadius = layer.radius || 5
+        const circleColor = config.color || '#99eeff'
+        const circleOpacity = config.opacity || 1
+        const circleStrokeColor = config.strokeColor || 'hsla(190, 100%, 45%, 0.5)'
+        const circleStrokeWidth = config.strokeWidth || 2
+        const circleRadius = config.radius || 5
         paint['circle-color'] = circleColor
         paint['circle-stroke-width'] = circleStrokeWidth
         paint['circle-radius'] = circleRadius
         paint['circle-stroke-color'] = circleStrokeColor
         if (hasSelectedFeatures) {
-          const { field = 'id', values, fallback = {} } = layer.selectedFeatures
+          const { field = 'id', values, fallback = {} } = config.selectedFeatures
           const {
             color = 'rgba(50, 139, 169, 0.3)',
             opacity = 1,
@@ -133,6 +133,29 @@ class CartoPolygonsGenerator {
 
       return { ...glLayer, layout, paint }
     })
+
+    const newLayers: any = []
+    // workaround to use line type for better rendering (uses antialiasing) but allows to fill the layer too
+    layers.forEach((layer: any) => {
+      if (layer.type === 'line' && config.selectedFeatures?.values?.length) {
+        const { field = 'id', values, fill = {} } = config.selectedFeatures
+        const { color = DEFAULT_LINE_COLOR } = fill
+        const matchFilter = ['match', ['get', field], values]
+        const paint: any = {
+          'fill-color': [...matchFilter, color, 'transparent'],
+          'fill-outline-color': 'transparent',
+        }
+        const newLayer = {
+          ...layer,
+          id: `${layer.id}_selected_features`,
+          type: 'fill',
+          paint,
+          layout: {},
+        }
+        newLayers.push(newLayer)
+      }
+    })
+    return layers.concat(newLayers)
   }
 
   getStyle = (layer: CartoPolygonsGeneratorConfig): GeneratorStyles => {

--- a/src/layer-composer/generators/track/track.ts
+++ b/src/layer-composer/generators/track/track.ts
@@ -143,7 +143,7 @@ class TrackGenerator {
       layout: {},
       paint: {
         'line-color': config.color || DEFAULT_TRACK_COLOR,
-        'line-opacity': 0.8,
+        'line-opacity': 0.9,
       },
       metadata: {
         group: Group.Track,

--- a/src/layer-composer/types.ts
+++ b/src/layer-composer/types.ts
@@ -13,7 +13,8 @@ export enum Group {
   Heatmap = 'heatmap', // Fill/gradient-based heatmaps
   BasemapFill = 'basemapFill', // Landmass
   BasemapPolygons = 'basemapPolygons', // Polygons  that need to be rendered below landmass
-  OutlinePolygons = 'outlinePolygons', // Conbtext layers with an outlined/hollow style such as EEZ, RFMOs, etc
+  OutlinePolygons = 'outlinePolygons', // Context layers with an outlined/hollow style such as EEZ, RFMOs, etc
+  OutlinePolygonsHighlighted = 'outlinePolygonsHighlighted', // Context layers with selected features
   Default = 'default', // Default stack position when group is not specified
   Point = 'point', // Events, etc
   Track = 'track', // Tracks

--- a/src/layer-composer/types.ts
+++ b/src/layer-composer/types.ts
@@ -12,6 +12,7 @@ export enum Group {
   Basemap = 'basemap', // Satellite tiles
   Heatmap = 'heatmap', // Fill/gradient-based heatmaps
   BasemapFill = 'basemapFill', // Landmass
+  BasemapPolygons = 'basemapPolygons', // Polygons  that need to be rendered below landmass
   OutlinePolygons = 'outlinePolygons', // Conbtext layers with an outlined/hollow style such as EEZ, RFMOs, etc
   Default = 'default', // Default stack position when group is not specified
   Point = 'point', // Events, etc

--- a/src/layer-composer/types.ts
+++ b/src/layer-composer/types.ts
@@ -12,8 +12,8 @@ export enum Group {
   Basemap = 'basemap', // Satellite tiles
   Heatmap = 'heatmap', // Fill/gradient-based heatmaps
   BasemapFill = 'basemapFill', // Landmass
-  BasemapPolygons = 'basemapPolygons', // Polygons  that need to be rendered below landmass
   OutlinePolygons = 'outlinePolygons', // Context layers with an outlined/hollow style such as EEZ, RFMOs, etc
+  OutlinePolygonsBackground = 'OutlinePolygonsBackground', // Polygons  that need to be rendered below landmass
   OutlinePolygonsHighlighted = 'outlinePolygonsHighlighted', // Context layers with selected features
   Default = 'default', // Default stack position when group is not specified
   Point = 'point', // Events, etc

--- a/src/sort/sort.ts
+++ b/src/sort/sort.ts
@@ -5,6 +5,7 @@ const GROUP_ORDER = [
   Group.Background,
   Group.Basemap,
   Group.Heatmap,
+  Group.BasemapPolygons,
   Group.BasemapFill,
   Group.OutlinePolygons,
   Group.Default,

--- a/src/sort/sort.ts
+++ b/src/sort/sort.ts
@@ -5,7 +5,7 @@ const GROUP_ORDER = [
   Group.Background,
   Group.Basemap,
   Group.Heatmap,
-  Group.BasemapPolygons,
+  Group.OutlinePolygonsBackground,
   Group.BasemapFill,
   Group.OutlinePolygons,
   Group.OutlinePolygonsHighlighted,

--- a/src/sort/sort.ts
+++ b/src/sort/sort.ts
@@ -8,6 +8,7 @@ const GROUP_ORDER = [
   Group.BasemapPolygons,
   Group.BasemapFill,
   Group.OutlinePolygons,
+  Group.OutlinePolygonsHighlighted,
   Group.Default,
   Group.Track,
   Group.TrackHighlightedEvent,


### PR DESCRIPTION
A lot of small changes to have granularity in carrier portal polygon layers and improve lines rendering.
- Updates eez source layer to avoid noise in the coastline
- Uses line instead of fill to improve antialiasing 
- New highlighted layer to ensure it always renders on top of the rest

An example: 
Before:
![image](https://user-images.githubusercontent.com/10500650/80522875-81d78280-898d-11ea-85a4-c519e8e46be2.png)

After:
![image](https://user-images.githubusercontent.com/10500650/80522632-2b6a4400-898d-11ea-8a58-368e40bf9559.png)

Pending: include types in this old generator